### PR TITLE
Fix DocumentScript type error in index.tsx

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -495,7 +495,10 @@ export const head: DocumentHead = {
   ],
   scripts: [
     {
-      children: JSON.stringify({
+      props: {
+        type: "application/ld+json",
+      },
+      script: JSON.stringify({
         "@context": "https://schema.org",
         "@type": "LocalBusiness",
         "name": "Top Shelf Advertising",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -495,7 +495,6 @@ export const head: DocumentHead = {
   ],
   scripts: [
     {
-      type: "application/ld+json",
       children: JSON.stringify({
         "@context": "https://schema.org",
         "@type": "LocalBusiness",


### PR DESCRIPTION
## Purpose
Fix TypeScript compilation error where the `type` property was incorrectly specified directly on the DocumentScript object instead of within the `props` property, causing the build to fail during linting.

## Code changes
- Moved `type: "application/ld+json"` from direct property to nested `props.type`
- Renamed `children` property to `script` to match the correct DocumentScript interface
- Updated JSON-LD structured data configuration in the document head scripts array

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3904f13941ea46179543ed7b19638c98/pulse-world)

👀 [Preview Link](https://3904f13941ea46179543ed7b19638c98-pulse-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3904f13941ea46179543ed7b19638c98</projectId>-->
<!--<branchName>pulse-world</branchName>-->